### PR TITLE
fix: Making github nullable to avoid edge-case

### DIFF
--- a/web/src/lib/rc_oauth.ts
+++ b/web/src/lib/rc_oauth.ts
@@ -6,7 +6,7 @@ export const RecurseResponse = z.object({
     last_name: z.string(),
     name: z.string(),
     email: z.string(),
-    github: z.string(),
+    github: z.string().nullable(),
     // TODO
 });
 


### PR DESCRIPTION
Ran into an edge-case where a fuzzy search for my GitHub username (which is just my name) produces a long list of other Recursers. If even one of those Recursers is missing a `github` username on their profile the Zod schema fails.

Here is where we're doing the RC API query:
- https://github.com/fcjr/RCade/blob/20b9a4d3dcdeb562d11a43bdf2f4156d2108179c/web/src/lib/recurse/index.ts#L28

You can look at the raw response here if you're logged into RC:
- https://www.recurse.com/api/v1/profiles?query=georgemandis

Do a find on the page for `"github":null` and you should find it.

**Why this matters**: I was getting a `Failed to create deployment intent: 401 Unauthorized - {"error":"Invalid OIDC token claims"}` error when trying to publish a game to RC!

**Idle thought**: would it make sense to give the other values a similar treatment? Email maybe? 