### PR TITLE
publish .d.ts files instead of raw .ts files

### DIFF
--- a/action-deploy/dist/main.js
+++ b/action-deploy/dist/main.js
@@ -58483,9 +58483,14 @@ function skipComment(str2, ptr) {
 }
 function skipVoid(str2, ptr, banNewLines, banComments) {
   let c;
-  while ((c = str2[ptr]) === " " || c === "	" || !banNewLines && (c === "\n" || c === "\r" && str2[ptr + 1] === "\n"))
-    ptr++;
-  return banComments || c !== "#" ? ptr : skipVoid(str2, skipComment(str2, ptr), banNewLines);
+  while (1) {
+    while ((c = str2[ptr]) === " " || c === "	" || !banNewLines && (c === "\n" || c === "\r" && str2[ptr + 1] === "\n"))
+      ptr++;
+    if (banComments || c !== "#")
+      break;
+    ptr = skipComment(str2, ptr);
+  }
+  return ptr;
 }
 function skipUntil(str2, ptr, sep, end, banNewLines = false) {
   if (!end) {

--- a/plugins/input-classic/clients/typescript/env.d.ts
+++ b/plugins/input-classic/clients/typescript/env.d.ts
@@ -1,0 +1,6 @@
+interface ImportMeta {
+    readonly hot?: {
+        accept(cb?: (mod: unknown) => void): void;
+        invalidate(): void;
+    };
+}

--- a/plugins/input-classic/clients/typescript/package.json
+++ b/plugins/input-classic/clients/typescript/package.json
@@ -1,26 +1,25 @@
 {
   "name": "@rcade/plugin-input-classic",
-  "module": "index.ts",
+  "module": "./dist/index.js",
   "main": "./dist/index.js",
   "version": "0.2.3",
   "type": "module",
-  "types": "./index.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk && tsc"
   },
   "files": [
-    "dist",
-    "index.ts"
+    "dist"
   ],
   "devDependencies": {},
   "dependencies": {
-    "@rcade/sdk": "^0.2.1"
+    "@rcade/sdk": "workspace:^"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/plugins/input-classic/clients/typescript/package.json
+++ b/plugins/input-classic/clients/typescript/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk && tsc"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk --sourcemap && tsc"
   },
   "files": [
     "dist"

--- a/plugins/input-classic/clients/typescript/tsconfig.json
+++ b/plugins/input-classic/clients/typescript/tsconfig.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
 

--- a/plugins/input-classic/clients/typescript/tsconfig.json
+++ b/plugins/input-classic/clients/typescript/tsconfig.json
@@ -10,9 +10,11 @@
 
     // Bundler mode
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
-    "noEmit": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
 
     // Best practices
     "strict": true,
@@ -23,5 +25,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "include": ["index.ts", "env.d.ts"]
 }

--- a/plugins/input-spinners/clients/typescript/env.d.ts
+++ b/plugins/input-spinners/clients/typescript/env.d.ts
@@ -1,0 +1,7 @@
+interface ImportMeta {
+    readonly hot?: {
+        accept(cb?: (mod: unknown) => void): void;
+        dispose(cb: () => void): void;
+        invalidate(): void;
+    };
+}

--- a/plugins/input-spinners/clients/typescript/package.json
+++ b/plugins/input-spinners/clients/typescript/package.json
@@ -1,26 +1,25 @@
 {
   "name": "@rcade/plugin-input-spinners",
-  "module": "index.ts",
+  "module": "./dist/index.js",
   "main": "./dist/index.js",
   "version": "0.2.2",
   "type": "module",
-  "types": "./index.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk && tsc"
   },
   "files": [
-    "dist",
-    "index.ts"
+    "dist"
   ],
   "devDependencies": {},
   "dependencies": {
-    "@rcade/sdk": "^0.2.2"
+    "@rcade/sdk": "workspace:^"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/plugins/input-spinners/clients/typescript/package.json
+++ b/plugins/input-spinners/clients/typescript/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk && tsc"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk --sourcemap && tsc"
   },
   "files": [
     "dist"

--- a/plugins/input-spinners/clients/typescript/tsconfig.json
+++ b/plugins/input-spinners/clients/typescript/tsconfig.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
 

--- a/plugins/input-spinners/clients/typescript/tsconfig.json
+++ b/plugins/input-spinners/clients/typescript/tsconfig.json
@@ -10,9 +10,11 @@
 
     // Bundler mode
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
-    "noEmit": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
 
     // Best practices
     "strict": true,
@@ -23,5 +25,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "include": ["index.ts", "env.d.ts"]
 }

--- a/plugins/menu/clients/typescript/package.json
+++ b/plugins/menu/clients/typescript/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk && tsc"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk --sourcemap && tsc"
   },
   "files": [
     "dist"

--- a/plugins/menu/clients/typescript/package.json
+++ b/plugins/menu/clients/typescript/package.json
@@ -1,26 +1,25 @@
 {
   "name": "@rcade/plugin-menu",
-  "module": "index.ts",
+  "module": "./dist/index.js",
   "main": "./dist/index.js",
   "version": "0.1.1",
   "type": "module",
-  "types": "./index.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk && tsc"
   },
   "files": [
-    "dist",
-    "index.ts"
+    "dist"
   ],
   "devDependencies": {},
   "dependencies": {
-    "@rcade/sdk": "^0.2.2"
+    "@rcade/sdk": "workspace:^"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/plugins/menu/clients/typescript/tsconfig.json
+++ b/plugins/menu/clients/typescript/tsconfig.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
 

--- a/plugins/menu/clients/typescript/tsconfig.json
+++ b/plugins/menu/clients/typescript/tsconfig.json
@@ -10,9 +10,11 @@
 
     // Bundler mode
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
-    "noEmit": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
 
     // Best practices
     "strict": true,
@@ -25,5 +27,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "include": ["index.ts"]
 }

--- a/plugins/sleep/clients/typescript/env.d.ts
+++ b/plugins/sleep/clients/typescript/env.d.ts
@@ -1,0 +1,6 @@
+interface ImportMeta {
+    readonly hot?: {
+        accept(cb?: (mod: unknown) => void): void;
+        invalidate(): void;
+    };
+}

--- a/plugins/sleep/clients/typescript/package.json
+++ b/plugins/sleep/clients/typescript/package.json
@@ -1,26 +1,25 @@
 {
   "name": "@rcade/plugin-sleep",
-  "module": "index.ts",
+  "module": "./dist/index.js",
   "main": "./dist/index.js",
   "version": "0.1.1",
   "type": "module",
-  "types": "./index.ts",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk && tsc"
   },
   "files": [
-    "dist",
-    "index.ts"
+    "dist"
   ],
   "devDependencies": {},
   "dependencies": {
-    "@rcade/sdk": "^0.2.2"
+    "@rcade/sdk": "workspace:^"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/plugins/sleep/clients/typescript/package.json
+++ b/plugins/sleep/clients/typescript/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk && tsc"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle --external:@rcade/sdk --sourcemap && tsc"
   },
   "files": [
     "dist"

--- a/plugins/sleep/clients/typescript/tsconfig.json
+++ b/plugins/sleep/clients/typescript/tsconfig.json
@@ -13,6 +13,7 @@
     "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
 

--- a/plugins/sleep/clients/typescript/tsconfig.json
+++ b/plugins/sleep/clients/typescript/tsconfig.json
@@ -10,10 +10,11 @@
 
     // Bundler mode
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": false,
     "verbatimModuleSyntax": true,
-    "noEmit": true,
     "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist",
 
     // Best practices
     "strict": true,
@@ -24,5 +25,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "include": ["index.ts", "env.d.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,8 +337,8 @@ importers:
   plugins/input-classic/clients/typescript:
     dependencies:
       '@rcade/sdk':
-        specifier: ^0.2.1
-        version: 0.2.2(typescript@5.9.3)
+        specifier: workspace:^
+        version: link:../../../../sdk/frontend/typescript
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -365,8 +365,8 @@ importers:
   plugins/input-spinners/clients/typescript:
     dependencies:
       '@rcade/sdk':
-        specifier: ^0.2.2
-        version: 0.2.2(typescript@5.9.3)
+        specifier: workspace:^
+        version: link:../../../../sdk/frontend/typescript
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -395,8 +395,8 @@ importers:
   plugins/menu/clients/typescript:
     dependencies:
       '@rcade/sdk':
-        specifier: ^0.2.2
-        version: 0.2.2(typescript@5.9.3)
+        specifier: workspace:^
+        version: link:../../../../sdk/frontend/typescript
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -413,8 +413,8 @@ importers:
   plugins/sleep/clients/typescript:
     dependencies:
       '@rcade/sdk':
-        specifier: ^0.2.2
-        version: 0.2.2(typescript@5.9.3)
+        specifier: workspace:^
+        version: link:../../../../sdk/frontend/typescript
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -2163,11 +2163,6 @@ packages:
     peerDependencies:
       typescript: ^5
 
-  '@rcade/sdk@0.2.2':
-    resolution: {integrity: sha512-K9Vq/YWGUdvNYXEWSwPFGy2GJ7wKQP1ePyhKFzcj7uRD+Hcg5W3TE8vlpTaIgI2GC56+s72H0Ngqhpq/CVuQRw==}
-    peerDependencies:
-      typescript: ^5.0.0
-
   '@reliverse/cfg@1.7.91':
     resolution: {integrity: sha512-FLYB8a2JyYDA2MvuyuoR/a7ywJR5sZJFAg9nxNvL2339CyOYVa9Z1r7B3hOnqPV+WYbhH9IvUfKO+NgTuQMRMg==}
 
@@ -3843,7 +3838,6 @@ packages:
 
   libsql@0.5.22:
     resolution: {integrity: sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.31.1:
@@ -6589,10 +6583,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@rcade/sdk@0.2.2(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
 
   '@reliverse/cfg@1.7.91': {}
 

--- a/sdk/frontend/typescript/package.json
+++ b/sdk/frontend/typescript/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@rcade/sdk",
   "version": "0.2.2",
-  "module": "index.ts",
+  "module": "./dist/index.js",
   "main": "./dist/index.js",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
@@ -14,9 +15,7 @@
     "build": "tsc --build tsconfig.json"
   },
   "files": [
-    "dist",
-    "src",
-    "index.ts"
+    "dist"
   ],
   "devDependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
This is the preferred method for public APIs in TS-land. In particular it lets the consumer (ie game dev) use a different or more strict tsconfig than the publishing library without causing problems.

It also seems necessary to provide some kind of `types` export from `sdk` to allow `tsc` to pass for consumers at all.

PS: Thanks, Claude