### PR TITLE
add types export to sdk/frontend

### DIFF
--- a/action-deploy/dist/main.js
+++ b/action-deploy/dist/main.js
@@ -58483,9 +58483,14 @@ function skipComment(str2, ptr) {
 }
 function skipVoid(str2, ptr, banNewLines, banComments) {
   let c;
-  while ((c = str2[ptr]) === " " || c === "	" || !banNewLines && (c === "\n" || c === "\r" && str2[ptr + 1] === "\n"))
-    ptr++;
-  return banComments || c !== "#" ? ptr : skipVoid(str2, skipComment(str2, ptr), banNewLines);
+  while (1) {
+    while ((c = str2[ptr]) === " " || c === "	" || !banNewLines && (c === "\n" || c === "\r" && str2[ptr + 1] === "\n"))
+      ptr++;
+    if (banComments || c !== "#")
+      break;
+    ptr = skipComment(str2, ptr);
+  }
+  return ptr;
 }
 function skipUntil(str2, ptr, sep, end, banNewLines = false) {
   if (!end) {

--- a/sdk/frontend/typescript/package.json
+++ b/sdk/frontend/typescript/package.json
@@ -7,17 +7,14 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
   "scripts": {
     "build": "tsc --build tsconfig.json"
   },
-  "files": [
-    "dist",
-    "src",
-    "index.ts"
-  ],
+  "files": ["dist", "src", "index.ts"],
   "devDependencies": {},
   "peerDependencies": {
     "typescript": "^5.0.0"


### PR DESCRIPTION
This is part of a simpler alternative https://github.com/fcjr/RCade/pull/115. This resolves one of the transitive type errors you get when running `npx tsc --watch` in a newly created project from `npm create rcade@latest`. We may still need to generate .d.ts files for `import.meta.hot`.

I'm not sure why `npm run build` made the change to `action-deploy/dist/main.js`