### PR TITLE
Add the ability to mark games as hidden in the game detail page

### DIFF
--- a/api/src/game/index.ts
+++ b/api/src/game/index.ts
@@ -45,7 +45,7 @@ export class Game {
     }
 
     public hidden(): boolean {
-        return this.apiResponse.hidden == 1;
+        return this.apiResponse.hidden === true;
     }
 
     public intoApiResponse(): any {

--- a/api/src/game/index.ts
+++ b/api/src/game/index.ts
@@ -44,6 +44,10 @@ export class Game {
         return this.apiResponse.git.ssh;
     }
 
+    public hidden(): boolean {
+        return this.apiResponse.hidden == 1;
+    }
+
     public intoApiResponse(): any {
         return this.apiResponse;
     }

--- a/web/drizzle/migrations/0019_loud_excalibur.sql
+++ b/web/drizzle/migrations/0019_loud_excalibur.sql
@@ -1,1 +1,0 @@
-ALTER TABLE `games` ADD `hidden` integer NOT NULL DEFAULT 0;

--- a/web/drizzle/migrations/0019_loud_excalibur.sql
+++ b/web/drizzle/migrations/0019_loud_excalibur.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `games` ADD `hidden` integer NOT NULL DEFAULT 0;

--- a/web/drizzle/migrations/0019_purple_centennial.sql
+++ b/web/drizzle/migrations/0019_purple_centennial.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `games` ADD `hidden` integer DEFAULT false NOT NULL;

--- a/web/drizzle/migrations/meta/0019_snapshot.json
+++ b/web/drizzle/migrations/meta/0019_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "f2d4ce3c-8f15-4794-81e0-1382a1fb45a6",
+  "id": "7d3d2892-92ef-4e84-afe2-5b689a151c63",
   "prevId": "27142313-24be-4009-8f86-96fcde28cf39",
   "tables": {
     "categories": {
@@ -436,7 +436,8 @@
           "type": "integer",
           "primaryKey": false,
           "notNull": true,
-          "autoincrement": false
+          "autoincrement": false,
+          "default": false
         }
       },
       "indexes": {

--- a/web/drizzle/migrations/meta/0019_snapshot.json
+++ b/web/drizzle/migrations/meta/0019_snapshot.json
@@ -1,0 +1,467 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f2d4ce3c-8f15-4794-81e0-1382a1fb45a6",
+  "prevId": "27142313-24be-4009-8f86-96fcde28cf39",
+  "tables": {
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_authors": {
+      "name": "game_authors",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_version": {
+          "name": "game_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recurse_id": {
+          "name": "recurse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_authors_game_id_version_idx": {
+          "name": "game_authors_game_id_version_idx",
+          "columns": [
+            "game_id",
+            "game_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_authors_game_id_game_version_game_versions_game_id_version_fk": {
+          "name": "game_authors_game_id_game_version_game_versions_game_id_version_fk",
+          "tableFrom": "game_authors",
+          "tableTo": "game_versions",
+          "columnsFrom": [
+            "game_id",
+            "game_version"
+          ],
+          "columnsTo": [
+            "game_id",
+            "version"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_dependencies": {
+      "name": "game_dependencies",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_version": {
+          "name": "game_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dependency_name": {
+          "name": "dependency_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dependency_version": {
+          "name": "dependency_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_dependencies_game_id_version_idx": {
+          "name": "game_dependencies_game_id_version_idx",
+          "columns": [
+            "game_id",
+            "game_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_dependencies_game_id_game_version_game_versions_game_id_version_fk": {
+          "name": "game_dependencies_game_id_game_version_game_versions_game_id_version_fk",
+          "tableFrom": "game_dependencies",
+          "tableTo": "game_versions",
+          "columnsFrom": [
+            "game_id",
+            "game_version"
+          ],
+          "columnsTo": [
+            "game_id",
+            "version"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_version_categories": {
+      "name": "game_version_categories",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_version": {
+          "name": "game_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_version_categories_game_id_version_idx": {
+          "name": "game_version_categories_game_id_version_idx",
+          "columns": [
+            "game_id",
+            "game_version"
+          ],
+          "isUnique": false
+        },
+        "game_version_categories_category_id_idx": {
+          "name": "game_version_categories_category_id_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "game_version_categories_game_id_game_version_category_id_unique": {
+          "name": "game_version_categories_game_id_game_version_category_id_unique",
+          "columns": [
+            "game_id",
+            "game_version",
+            "category_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_version_categories_category_id_categories_id_fk": {
+          "name": "game_version_categories_category_id_categories_id_fk",
+          "tableFrom": "game_version_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_version_categories_game_id_game_version_game_versions_game_id_version_fk": {
+          "name": "game_version_categories_game_id_game_version_game_versions_game_id_version_fk",
+          "tableFrom": "game_version_categories",
+          "tableTo": "game_versions",
+          "columnsFrom": [
+            "game_id",
+            "game_version"
+          ],
+          "columnsTo": [
+            "game_id",
+            "version"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_versions": {
+      "name": "game_versions",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_thumbnail": {
+          "name": "has_thumbnail",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remix_of_game_id": {
+          "name": "remix_of_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remix_of_version": {
+          "name": "remix_of_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_versions_game_id_idx": {
+          "name": "game_versions_game_id_idx",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "game_versions_game_id_version_unique": {
+          "name": "game_versions_game_id_version_unique",
+          "columns": [
+            "game_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_versions_game_id_games_id_fk": {
+          "name": "game_versions_game_id_games_id_fk",
+          "tableFrom": "game_versions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_versions_remix_of_game_id_remix_of_version_game_versions_game_id_version_fk": {
+          "name": "game_versions_remix_of_game_id_remix_of_version_game_versions_game_id_version_fk",
+          "tableFrom": "game_versions",
+          "tableTo": "game_versions",
+          "columnsFrom": [
+            "remix_of_game_id",
+            "remix_of_version"
+          ],
+          "columnsTo": [
+            "game_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "games": {
+      "name": "games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_author": {
+          "name": "github_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_rc_id": {
+          "name": "owner_rc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "admin_lock_reason": {
+          "name": "admin_lock_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "games_name_idx": {
+          "name": "games_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/migrations/meta/_journal.json
+++ b/web/drizzle/migrations/meta/_journal.json
@@ -138,8 +138,8 @@
     {
       "idx": 19,
       "version": "6",
-      "when": 1780932340776,
-      "tag": "0019_loud_excalibur",
+      "when": 1781547452526,
+      "tag": "0019_purple_centennial",
       "breakpoints": true
     }
   ]

--- a/web/drizzle/migrations/meta/_journal.json
+++ b/web/drizzle/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1765517696335,
       "tag": "0018_modern_marvel_apes",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1780932340776,
+      "tag": "0019_loud_excalibur",
+      "breakpoints": true
     }
   ]
 }

--- a/web/scripts/pull-db.js
+++ b/web/scripts/pull-db.js
@@ -1,7 +1,6 @@
 import { drizzle } from 'drizzle-orm/d1';
 import { rm } from 'fs/promises';
 import { execSync } from 'child_process';
-import * as schema from '../src/lib/db/schema';
 import { sql } from 'drizzle-orm';
 
 // Colors and formatting

--- a/web/src/lib/db/schema.ts
+++ b/web/src/lib/db/schema.ts
@@ -18,7 +18,7 @@ export const games = sqliteTable('games', {
     github_repo: text("github_repo").notNull(),
     owner_rc_id: numeric("owner_rc_id").notNull(),
     admin_lock_reason: text("admin_lock_reason"),
-    hidden: integer("hidden").notNull().$default(() => 0),
+    hidden: integer("hidden", { mode: "boolean" }).notNull().default(false),
 }, (t) => [
     index("games_name_idx").on(t.name),
 ]);

--- a/web/src/lib/db/schema.ts
+++ b/web/src/lib/db/schema.ts
@@ -18,6 +18,7 @@ export const games = sqliteTable('games', {
     github_repo: text("github_repo").notNull(),
     owner_rc_id: numeric("owner_rc_id").notNull(),
     admin_lock_reason: text("admin_lock_reason"),
+    hidden: integer("hidden").notNull().$default(() => 0),
 }, (t) => [
     index("games_name_idx").on(t.name),
 ]);

--- a/web/src/lib/game.ts
+++ b/web/src/lib/game.ts
@@ -346,6 +346,10 @@ export class Game {
             return undefined;
         }
 
+        if (this.data.hidden == 1 && auth.for === "cabinet") {
+            return undefined;
+        }
+
         const versions = (await Promise.all(this.data.versions.map(async version => {
             if (version.status !== "published") {
                 return undefined;
@@ -420,6 +424,7 @@ export class Game {
         return {
             id: this.data.id,
             name: this.data.name,
+            hidden: this.data.hidden,
             admin_lock_reason: this.data.admin_lock_reason,
             git: {
                 ssh: `git@github.com:${this.data.github_repo}.git`,
@@ -454,6 +459,14 @@ export class Game {
 
         return result.length > 0;
     }
+
+    public async setHidden(hidden: boolean): Promise<void> {
+        await (await getDb()).update(games)
+            .set({ hidden: hidden ? 1 : 0 })
+            .where(eq(games.id, this.data.id))
+            .run();
+    }
+
 
     public async markVersionHasThumbnail(version: string): Promise<void> {
         await (await getDb()).update(gameVersions)

--- a/web/src/lib/game.ts
+++ b/web/src/lib/game.ts
@@ -346,7 +346,7 @@ export class Game {
             return undefined;
         }
 
-        if (this.data.hidden == 1 && auth.for === "cabinet") {
+        if (this.data.hidden && auth.for === "cabinet") {
             return undefined;
         }
 
@@ -462,11 +462,10 @@ export class Game {
 
     public async setHidden(hidden: boolean): Promise<void> {
         await (await getDb()).update(games)
-            .set({ hidden: hidden ? 1 : 0 })
+            .set({ hidden })
             .where(eq(games.id, this.data.id))
             .run();
     }
-
 
     public async markVersionHasThumbnail(version: string): Promise<void> {
         await (await getDb()).update(gameVersions)

--- a/web/src/routes/api/v1/games/[game_id]/+server.ts
+++ b/web/src/routes/api/v1/games/[game_id]/+server.ts
@@ -40,9 +40,9 @@ export const GET: RequestHandler = async ({ locals, params, request }) => {
 
 export const PATCH: RequestHandler = async ({ locals, params, request }) => {
     const session = await locals.auth();
-    const auth = session?.user ? { for: <const>"recurser", rc_id: session.user.rc_id } : request.headers.get("Authorization") == `Bearer ${env.CABINET_API_KEY}` ? { for: <const>"cabinet" } : { for: <const>"public" };
 
-    if (auth.for === "public") {
+    // TODO: scope this to the game's owner (owner_rc_id) rather than any authenticated Recurser.
+    if (!session?.user) {
         return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
     }
 
@@ -53,7 +53,7 @@ export const PATCH: RequestHandler = async ({ locals, params, request }) => {
         }
 
         const body = await request.json();
-        const hidden = body.hidden ?? false;
+        const hidden = body.hidden === true;
 
         const game = await Game.byId(gameId);
         if (!game) {

--- a/web/src/routes/api/v1/games/[game_id]/+server.ts
+++ b/web/src/routes/api/v1/games/[game_id]/+server.ts
@@ -37,3 +37,38 @@ export const GET: RequestHandler = async ({ locals, params, request }) => {
         );
     }
 };
+
+export const PATCH: RequestHandler = async ({ locals, params, request }) => {
+    const session = await locals.auth();
+    const auth = session?.user ? { for: <const>"recurser", rc_id: session.user.rc_id } : request.headers.get("Authorization") == `Bearer ${env.CABINET_API_KEY}` ? { for: <const>"cabinet" } : { for: <const>"public" };
+
+    if (auth.for === "public") {
+        return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    try {
+        const gameId = params.game_id ?? "";
+        if (!gameId) {
+            return new Response(JSON.stringify({ error: 'Game ID is required' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+        }
+
+        const body = await request.json();
+        const hidden = body.hidden ?? false;
+
+        const game = await Game.byId(gameId);
+        if (!game) {
+            return new Response(JSON.stringify({ error: 'Game not found' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+        }
+
+        await game.setHidden(hidden);
+
+        return new Response(JSON.stringify({ success: true }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    } catch (error) {
+        console.error('Database error:', error);
+
+        return new Response(
+            JSON.stringify({ error: 'Failed to update game' }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } }
+        );
+    }
+};

--- a/web/src/routes/games/[game_name]/[[game_version]]/+page.svelte
+++ b/web/src/routes/games/[game_name]/[[game_version]]/+page.svelte
@@ -93,7 +93,7 @@
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({ hidden: next })
 			});
-			if (!res.ok) hidden = !next; 
+			if (!res.ok) hidden = !next;
 		} catch {
 			hidden = !next;
 		}

--- a/web/src/routes/games/[game_name]/[[game_version]]/+page.svelte
+++ b/web/src/routes/games/[game_name]/[[game_version]]/+page.svelte
@@ -78,6 +78,27 @@
 		handleUpdate(data.game, data.version);
 	});
 
+	let hidden = $state(false);
+
+	$effect(() => {
+		hidden = data.game.hidden();
+	});
+
+	async function toggleHidden() {
+		const next = !hidden;
+		hidden = next;
+		try {
+			const res = await fetch(`/api/v1/games/${data.game.id()}`, {
+				method: 'PATCH',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ hidden: next })
+			});
+			if (!res.ok) hidden = !next; 
+		} catch {
+			hidden = !next;
+		}
+	}
+
 	async function handleUpdate(game: Game, version: GameVersion) {
 		if (ENGINE == undefined) return undefined;
 
@@ -301,6 +322,16 @@
 							{data.version.visibility()?.toUpperCase()}
 						</div>
 					</div>
+					{#if data.session?.user?.rc_id}
+						<button class="sys-chip cursor-pointer" onclick={toggleHidden}>
+							<span class="chip-label icon-label">
+								<span>HIDE ON CABINET</span>
+							</span>
+							<div class="chip-value">
+								{hidden ? 'TRUE' : 'FALSE'}
+							</div>
+						</button>
+					{/if}
 
 					{#each data.version.dependencies() as dep}
 						<div class="sys-chip">


### PR DESCRIPTION
The game detail page will now have a HIDE ON CABINET flag: 

<img width="517" height="246" alt="Screenshot 2026-06-08 at 1 38 23 PM" src="https://github.com/user-attachments/assets/ef3b5192-30da-4d4c-9d74-3fc96e98fc04" />

The flag will be toggled on click. 

If true, the game will be hidden from the cabinet. Only logged in users will be able to see + click the toggle. 

There is currently no check for if the logged in recurser is the owner for the game. 
