### PR TITLE
Add event-based auth: rcade register, cabinet TOTP display, deploy fallback

### DIFF
--- a/action-deploy/dist/main.js
+++ b/action-deploy/dist/main.js
@@ -37366,7 +37366,7 @@ var GameVersionResponse = external_exports.object({
       ssh: external_exports.string(),
       https: external_exports.string()
     }),
-    owner_rc_id: external_exports.string(),
+    owner_rc_id: external_exports.string().nullable(),
     version: external_exports.object({
       displayName: external_exports.string().nullable().optional(),
       description: external_exports.string(),
@@ -37393,10 +37393,27 @@ var GameResponse = external_exports.object({
     ssh: external_exports.string(),
     https: external_exports.string()
   }),
-  owner_rc_id: external_exports.string(),
+  owner_rc_id: external_exports.string().nullable(),
   versions: external_exports.array(GameVersionResponse)
 });
 var GamesResponse = external_exports.array(GameResponse);
+var CurrentEventResponse = external_exports.discriminatedUnion("active", [
+  external_exports.object({
+    active: external_exports.literal(false),
+    server_time: external_exports.number()
+  }),
+  external_exports.object({
+    active: external_exports.literal(true),
+    event: external_exports.object({
+      id: external_exports.string(),
+      name: external_exports.string(),
+      starts_at: external_exports.string(),
+      ends_at: external_exports.string(),
+      totp_secret: external_exports.string()
+    }),
+    server_time: external_exports.number()
+  })
+]);
 var ManifestAuthor2 = object({
   display_name: string2(),
   recurse_id: number2().optional()

--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,8 @@
     }
   },
   "scripts": {
-    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle && tsc -p tsconfig.build.json --emitDeclarationOnly"
+    "build": "esbuild index.ts --outdir=dist --platform=node --format=esm --bundle && tsc -p tsconfig.build.json --emitDeclarationOnly",
+    "test": "pnpm run build && node --test test/*.test.mjs"
   },
   "files": [
     "dist"

--- a/api/src/client.ts
+++ b/api/src/client.ts
@@ -1,5 +1,5 @@
 import { Game } from "./game/index.js";
-import { GamesResponse, GameResponse } from "./schema.js";
+import { CurrentEventResponse, GamesResponse, GameResponse } from "./schema.js";
 
 export class Client {
   public static new() {
@@ -39,5 +39,18 @@ export class Client {
       headers: this.headers,
     });
     return Game.fromApiResponse(await response.json());
+  }
+
+  public async getCurrentEvent(): Promise<CurrentEventResponse> {
+    const response = await fetch(`${this.baseUrl}/events/current`, {
+      headers: this.headers,
+    });
+    const body = await response.text();
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch current event: ${response.status} ${body}`);
+    }
+
+    return CurrentEventResponse.parse(JSON.parse(body));
   }
 }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,7 +2,8 @@ export { Manifest as GameManifest, ManifestAuthor as GameManifestAuthor, Permiss
 export { Game } from "./game/index.js";
 export { GameVersion } from "./game/version.js";
 export { Client } from "./client.js";
-export { GameResponse, GamesResponse, GameVersionResponse } from "./schema.js";
+export { GameResponse, GamesResponse, GameVersionResponse, CurrentEventResponse } from "./schema.js";
+export { generateTotp, TOTP_PARAMS, type TotpParams } from "./totp.js";
 export { PluginManifest, PluginManifestAuthor } from "./plugin/index.js";
 export { pluginManifests } from "./plugins.js";
 export { PluginDetector } from "./detect/index.js";

--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -27,7 +27,7 @@ export const GameVersionResponse = z.object({
       ssh: z.string(),
       https: z.string(),
     }),
-    owner_rc_id: z.string(),
+    owner_rc_id: z.string().nullable(),
     version: z.object({
       displayName: z.string().nullable().optional(),
       description: z.string(),
@@ -55,11 +55,30 @@ export const GameResponse = z.object({
     ssh: z.string(),
     https: z.string(),
   }),
-  owner_rc_id: z.string(),
+  owner_rc_id: z.string().nullable(),
   versions: z.array(GameVersionResponse),
 });
 
 export const GamesResponse = z.array(GameResponse);
 
+export const CurrentEventResponse = z.discriminatedUnion("active", [
+  z.object({
+    active: z.literal(false),
+    server_time: z.number(),
+  }),
+  z.object({
+    active: z.literal(true),
+    event: z.object({
+      id: z.string(),
+      name: z.string(),
+      starts_at: z.string(),
+      ends_at: z.string(),
+      totp_secret: z.string(),
+    }),
+    server_time: z.number(),
+  }),
+]);
+
 export type GameResponse = z.infer<typeof GameResponse>;
 export type GamesResponse = z.infer<typeof GamesResponse>;
+export type CurrentEventResponse = z.infer<typeof CurrentEventResponse>;

--- a/api/src/totp.ts
+++ b/api/src/totp.ts
@@ -1,0 +1,49 @@
+// RFC 6238 TOTP over WebCrypto. This module must stay portable across
+// Cloudflare Workers, browsers, Electron main, and Node — use only
+// globalThis.crypto, never node:crypto.
+
+export const TOTP_PARAMS = { digits: 6, periodSeconds: 30 } as const;
+
+export type TotpParams = { digits: number; periodSeconds: number };
+
+function hexToBytes(hex: string): Uint8Array<ArrayBuffer> {
+  if (hex.length % 2 !== 0 || /[^0-9a-fA-F]/.test(hex)) {
+    throw new Error("TOTP secret must be a hex string");
+  }
+
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+export async function generateTotp(
+  secretHex: string,
+  timeMs: number,
+  opts: TotpParams = TOTP_PARAMS,
+): Promise<string> {
+  const counter = Math.floor(timeMs / 1000 / opts.periodSeconds);
+
+  const message = new Uint8Array(8);
+  new DataView(message.buffer).setBigUint64(0, BigInt(counter));
+
+  const key = await globalThis.crypto.subtle.importKey(
+    "raw",
+    hexToBytes(secretHex),
+    { name: "HMAC", hash: "SHA-1" },
+    false,
+    ["sign"],
+  );
+  const hmac = new Uint8Array(await globalThis.crypto.subtle.sign("HMAC", key, message));
+
+  // Dynamic truncation (RFC 4226 §5.3)
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const binCode =
+    ((hmac[offset] & 0x7f) << 24) |
+    (hmac[offset + 1] << 16) |
+    (hmac[offset + 2] << 8) |
+    hmac[offset + 3];
+
+  return (binCode % 10 ** opts.digits).toString().padStart(opts.digits, "0");
+}

--- a/api/test/totp.test.mjs
+++ b/api/test/totp.test.mjs
@@ -1,0 +1,51 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateTotp, TOTP_PARAMS } from "../dist/index.js";
+
+// RFC 6238 Appendix B test vectors (SHA-1). Secret is the ASCII string
+// "12345678901234567890" as hex; vectors are 8 digits, 30s period.
+const RFC_SECRET_HEX = "3132333435363738393031323334353637383930";
+const RFC_PARAMS = { digits: 8, periodSeconds: 30 };
+const RFC_VECTORS = [
+  [59, "94287082"],
+  [1111111109, "07081804"],
+  [1111111111, "14050471"],
+  [1234567890, "89005924"],
+  [2000000000, "69279037"],
+  [20000000000, "65353130"],
+];
+
+test("RFC 6238 SHA-1 test vectors", async () => {
+  for (const [timeSeconds, expected] of RFC_VECTORS) {
+    const code = await generateTotp(RFC_SECRET_HEX, timeSeconds * 1000, RFC_PARAMS);
+    assert.equal(code, expected, `T=${timeSeconds}`);
+  }
+});
+
+test("default params are 6 digits / 30s", () => {
+  assert.deepEqual(TOTP_PARAMS, { digits: 6, periodSeconds: 30 });
+});
+
+test("6-digit codes match the RFC vectors truncated to 6 digits", async () => {
+  for (const [timeSeconds, expected] of RFC_VECTORS) {
+    const code = await generateTotp(RFC_SECRET_HEX, timeSeconds * 1000);
+    assert.equal(code, expected.slice(-6), `T=${timeSeconds}`);
+  }
+});
+
+test("code is stable within a period and changes across the boundary", async () => {
+  const base = 1_700_000_010_000; // 10s into a 30s period
+  assert.equal(
+    await generateTotp(RFC_SECRET_HEX, base),
+    await generateTotp(RFC_SECRET_HEX, base + 19_999),
+  );
+  assert.notEqual(
+    await generateTotp(RFC_SECRET_HEX, base),
+    await generateTotp(RFC_SECRET_HEX, base + 30_000),
+  );
+});
+
+test("rejects non-hex secrets", async () => {
+  await assert.rejects(() => generateTotp("not-hex!", 0));
+  await assert.rejects(() => generateTotp("abc", 0)); // odd length
+});

--- a/cabinet/src/main/main.ts
+++ b/cabinet/src/main/main.ts
@@ -62,6 +62,9 @@ if (process.platform === 'linux') {
 
 const cabinetApiKey = process.env.CABINET_API_KEY;
 const apiClient = cabinetApiKey ? Client.newKeyed(cabinetApiKey) : Client.new();
+if (process.env.RCADE_API_URL) {
+  apiClient.withBaseUrl(process.env.RCADE_API_URL);
+}
 
 // Cache directory for game files
 const cacheDir = path.join(app.getPath('userData'), 'game-cache');

--- a/cli/bin.ts
+++ b/cli/bin.ts
@@ -7,6 +7,7 @@ import { devCommand } from "./src/dev";
 import { playCommand } from "./src/play";
 import { cacheCommand } from "./src/cache";
 import { remixCommand } from "./src/remix";
+import { registerCommand } from "./src/register";
 
 const program = new Command();
 
@@ -20,5 +21,6 @@ program.addCommand(devCommand);
 program.addCommand(playCommand);
 program.addCommand(cacheCommand);
 program.addCommand(remixCommand);
+program.addCommand(registerCommand);
 
 program.parse();

--- a/cli/src/register.ts
+++ b/cli/src/register.ts
@@ -1,0 +1,63 @@
+import { Command } from "commander";
+import { input } from "@inquirer/prompts";
+
+const RCADE_API = process.env.RCADE_API_URL ?? "https://rcade.dev/api/v1";
+
+// GitHub username rules: 1-39 chars, alphanumeric with inner hyphens
+const GITHUB_USERNAME_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
+const CODE_REGEX = /^\d{6}$/;
+
+export const registerCommand = new Command("register")
+    .description("register your GitHub account for the current RCade event")
+    .argument("[github-username]", "GitHub username that owns the repo you'll push from")
+    .argument("[code]", "6-digit event code shown on the cabinet")
+    .action(async (githubUsername: string | undefined, code: string | undefined) => {
+        try {
+            if (!githubUsername) {
+                githubUsername = await input({
+                    message: "GitHub username (the account that owns the repo you'll push from):",
+                    validate: (value) => {
+                        if (!GITHUB_USERNAME_REGEX.test(value.trim())) {
+                            return "That doesn't look like a GitHub username";
+                        }
+                        return true;
+                    },
+                });
+            }
+            githubUsername = githubUsername.trim();
+
+            if (!code) {
+                code = await input({
+                    message: "Event code (shown on the cabinet screen):",
+                    validate: (value) => {
+                        if (!CODE_REGEX.test(value.trim())) {
+                            return "The event code is 6 digits";
+                        }
+                        return true;
+                    },
+                });
+            }
+            code = code.trim();
+
+            const response = await fetch(`${RCADE_API}/events/auth`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ github_username: githubUsername, code }),
+            });
+
+            const body = (await response.json().catch(() => ({}))) as any;
+
+            if (!response.ok) {
+                throw new Error(body.error ?? `Registration failed: ${response.status} ${response.statusText}`);
+            }
+
+            const eventNames = (body.events ?? []).map((event: any) => event.name).join(", ");
+            console.log(`✓ Registered ${body.github_username} for ${eventNames || "the current event"}.`);
+            console.log("");
+            console.log("You can now deploy games! Make sure your game's GitHub repo is public");
+            console.log(`and owned by ${body.github_username}, then push to deploy.`);
+        } catch (error) {
+            console.error("Error:", error instanceof Error ? error.message : error);
+            process.exit(1);
+        }
+    });

--- a/menu/src/routes/+page.svelte
+++ b/menu/src/routes/+page.svelte
@@ -2,12 +2,15 @@
     import BackgroundOverlay from "$lib/components/BackgroundOverlay.svelte";
     import { fly, slide } from "svelte/transition";
     import {
+        getEventCode,
         getGames,
         getLastGame,
+        onEventCode,
         onGameLoad,
         onGameQuit,
         onMenuRequested,
         playGame,
+        type EventCodeStatus,
     } from "@rcade/plugin-menu";
     import { quartOut } from "svelte/easing";
     import { tick, onMount } from "svelte";
@@ -180,6 +183,10 @@
     let games: Game[] = [];
     let loading = true;
 
+    // Rotating event code, minted by the cabinet and pushed over the plugin
+    // channel while an event is active.
+    let eventStatus: EventCodeStatus = { active: false };
+
     onMount(() => {
         // Register input handlers
         const unsubPress = registerPressHandler();
@@ -188,6 +195,14 @@
         // Subscribe to menu key to refresh games list
         onMenuRequested(() => {
             refreshGames();
+        });
+
+        // Event code: pull current state now, then follow rotation pushes
+        onEventCode((status) => {
+            eventStatus = status;
+        });
+        getEventCode().then((status) => {
+            eventStatus = status;
         });
 
         preloadMenuSound();
@@ -832,6 +847,14 @@
                         </div>
                     </div>
 
+                    {#if eventStatus.active}
+                        <div class="event-line">
+                            <span>{eventStatus.name} Event Code</span>
+                            <span class="event-line-dot">·</span>
+                            <span class="event-line-code">{eventStatus.code}</span>
+                        </div>
+                    {/if}
+
                 </div>
 
                 <div class="content-stage">
@@ -1332,6 +1355,26 @@
         justify-content: center;
         margin-top: -40px;
         margin-bottom: -40px;
+    }
+
+    .event-line {
+        margin-top: -4px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-family: var(--font-mono);
+        color: var(--color-primary);
+        font-size: 12px;
+        letter-spacing: 0.1em;
+    }
+
+    .event-line-dot {
+        opacity: 0.5;
+    }
+
+    .event-line-code {
+        font-weight: bold;
+        letter-spacing: 0.2em;
     }
 
     .pagination-scroll {

--- a/plugins/menu/clients/typescript/index.ts
+++ b/plugins/menu/clients/typescript/index.ts
@@ -18,6 +18,10 @@ let channel: Promise<PluginChannel> | null = null;
             if (event.data.type === "menu_requested") {
                 menuRequestHandler?.();
             }
+
+            if (event.data.type === "event_code" && event.data.nonce === undefined) {
+                eventCodeHandler?.(event.data.content);
+            }
         })
 
         channel.getPort().start();
@@ -112,4 +116,45 @@ export function onGameLoad(handler: (result: any) => void) {
 let menuRequestHandler: (() => void) | undefined = undefined;
 export function onMenuRequested(handler: () => void) {
     menuRequestHandler = handler;
+}
+
+export type EventCodeStatus = {
+    active: boolean;
+    name?: string;
+    code?: string;
+};
+
+let eventCodeHandler: ((status: EventCodeStatus) => void) | undefined = undefined;
+export function onEventCode(handler: (status: EventCodeStatus) => void) {
+    eventCodeHandler = handler;
+}
+
+export async function getEventCode(): Promise<EventCodeStatus> {
+    if (!channel) {
+        throw new Error("Plugin channel not initialized");
+    }
+
+    const cha = await channel;
+    const port = cha.getPort();
+
+    port.start();
+
+    return await new Promise(res => {
+        const nonce = crypto.randomUUID();
+
+        const handleMessage = (event: MessageEvent) => {
+            const { type, nonce: responseNonce, content } = event.data;
+
+            if (responseNonce !== nonce) {
+                return;
+            }
+
+            if (type == "event-code") {
+                port.removeEventListener("message", handleMessage);
+                res(content);
+            }
+        };
+        port.addEventListener("message", handleMessage);
+        port.postMessage({ type: "get-event-code", nonce, content: {} });
+    });
 }

--- a/plugins/menu/clients/typescript/package.json
+++ b/plugins/menu/clients/typescript/package.json
@@ -2,7 +2,7 @@
   "name": "@rcade/plugin-menu",
   "module": "index.ts",
   "main": "./dist/index.js",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "types": "./index.ts",
   "exports": {

--- a/plugins/menu/index.ts
+++ b/plugins/menu/index.ts
@@ -1,4 +1,4 @@
-import { Client, Game } from "@rcade/api";
+import { Client, Game, generateTotp, TOTP_PARAMS } from "@rcade/api";
 import { type PluginEnvironment, type Plugin } from "@rcade/sdk-plugin";
 import { app } from "electron";
 import path from "node:path";
@@ -9,6 +9,9 @@ import type { QuitOptions } from "@rcade/sdk";
 
 const cabinetApiKey = process.env.CABINET_API_KEY;
 const apiClient = cabinetApiKey ? Client.newKeyed(cabinetApiKey) : Client.new();
+if (process.env.RCADE_API_URL) {
+    apiClient.withBaseUrl(process.env.RCADE_API_URL);
+}
 const cacheDir = path.join(app.getPath('userData'), 'game-cache');
 const gamesListCachePath = path.join(app.getPath('userData'), 'games-list.json');
 
@@ -19,6 +22,23 @@ async function saveGamesListCache(games: {}[]): Promise<void> {
 function getCachePath(gameId: string, version: string): string {
     return path.join(cacheDir, gameId, version);
 }
+
+const EVENT_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+const CLOCK_SKEW_WARN_MS = 10_000;
+
+type CachedEvent = {
+    id: string;
+    name: string;
+    startsAtMs: number;
+    endsAtMs: number;
+    totpSecret: string;
+};
+
+type EventCodeStatus = {
+    active: boolean;
+    name?: string;
+    code?: string;
+};
 
 type GameInfo = {
     id: string;
@@ -47,6 +67,10 @@ async function isGameCached(gameId: string, version: string): Promise<boolean> {
 }
 
 export default class MenuPlugin implements Plugin {
+    private currentEvent: CachedEvent | null = null;
+    private eventRefreshTimer: ReturnType<typeof setInterval> | undefined;
+    private codePushTimer: ReturnType<typeof setTimeout> | undefined;
+
     start(environment: PluginEnvironment): void {
         SETTINGS.load();
 
@@ -82,6 +106,13 @@ export default class MenuPlugin implements Plugin {
                 port.postMessage({ type: "last-game", nonce, content: { lastGameId: SETTINGS.lastGameId } });
                 return;
             }
+
+            if (type === "get-event-code") {
+                this.eventCodeStatus().then(content => {
+                    port.postMessage({ type: "event-code", nonce, content });
+                });
+                return;
+            }
         });
 
         // @ts-ignore
@@ -100,10 +131,73 @@ export default class MenuPlugin implements Plugin {
         });
 
         port.start();
+
+        // The cabinet is the clock for event codes: fetch the event (incl. TOTP
+        // secret) from the API, then mint display codes locally so a network
+        // blip doesn't blank the code on screen. The menu iframe only ever
+        // receives the derived code, never the secret.
+        this.refreshEvent().then(() => this.scheduleCodePushes(port));
+        this.eventRefreshTimer = setInterval(() => this.refreshEvent(), EVENT_REFRESH_INTERVAL_MS);
     }
 
     stop(): void {
         console.log(`[@rcade/menu] Menu plugin stopped`);
+
+        clearInterval(this.eventRefreshTimer);
+        clearTimeout(this.codePushTimer);
+    }
+
+    private async refreshEvent(): Promise<void> {
+        try {
+            const response = await apiClient.getCurrentEvent();
+
+            const skewMs = response.server_time - Date.now();
+            if (Math.abs(skewMs) > CLOCK_SKEW_WARN_MS) {
+                console.error(`[@rcade/menu] Cabinet clock differs from server by ${Math.round(skewMs / 1000)}s — event codes may fail to verify. Check NTP.`);
+            }
+
+            if (response.active) {
+                this.currentEvent = {
+                    id: response.event.id,
+                    name: response.event.name,
+                    startsAtMs: Date.parse(response.event.starts_at),
+                    endsAtMs: Date.parse(response.event.ends_at),
+                    totpSecret: response.event.totp_secret,
+                };
+            } else {
+                this.currentEvent = null;
+            }
+        } catch (err) {
+            // offline: keep the cached event and keep minting codes until it ends
+            console.log('[@rcade/menu] Failed to refresh current event, keeping cached state:', err);
+        }
+    }
+
+    private async eventCodeStatus(): Promise<EventCodeStatus> {
+        const event = this.currentEvent;
+        const now = Date.now();
+
+        if (!event || now < event.startsAtMs || now > event.endsAtMs) {
+            return { active: false };
+        }
+
+        return {
+            active: true,
+            name: event.name,
+            code: await generateTotp(event.totpSecret, now),
+        };
+    }
+
+    private scheduleCodePushes(port: ReturnType<PluginEnvironment["getPort"]>): void {
+        const push = async () => {
+            port.postMessage({ type: "event_code", content: await this.eventCodeStatus() });
+
+            const stepMs = TOTP_PARAMS.periodSeconds * 1000;
+            // wake just past the next code rotation boundary
+            this.codePushTimer = setTimeout(push, stepMs - (Date.now() % stepMs) + 50);
+        };
+
+        push();
     }
 
     private async getGames(): Promise<any[]> {

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -17,6 +17,7 @@ Thumbs.db
 .env.*
 !.env.example
 !.env.test
+.dev.vars
 
 # Vite
 vite.config.js.timestamp-*

--- a/web/drizzle/migrations/0020_furry_bushwacker.sql
+++ b/web/drizzle/migrations/0020_furry_bushwacker.sql
@@ -1,0 +1,47 @@
+CREATE TABLE `event_authentications` (
+	`id` text PRIMARY KEY NOT NULL,
+	`event_id` text NOT NULL,
+	`github_username` text NOT NULL,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `event_authentications_github_username_idx` ON `event_authentications` (`github_username`);--> statement-breakpoint
+CREATE UNIQUE INDEX `event_authentications_event_id_github_username_unique` ON `event_authentications` (`event_id`,`github_username`);--> statement-breakpoint
+CREATE TABLE `events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`starts_at` integer NOT NULL,
+	`ends_at` integer NOT NULL,
+	`totp_secret` text NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `events_starts_at_ends_at_idx` ON `events` (`starts_at`,`ends_at`);--> statement-breakpoint
+PRAGMA defer_foreign_keys = on;--> statement-breakpoint
+CREATE TABLE `__tmp_game_versions` AS SELECT * FROM `game_versions`;--> statement-breakpoint
+CREATE TABLE `__tmp_game_authors` AS SELECT * FROM `game_authors`;--> statement-breakpoint
+CREATE TABLE `__tmp_game_dependencies` AS SELECT * FROM `game_dependencies`;--> statement-breakpoint
+CREATE TABLE `__tmp_game_version_categories` AS SELECT * FROM `game_version_categories`;--> statement-breakpoint
+CREATE TABLE `__new_games` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`github_author` text NOT NULL,
+	`github_repo` text NOT NULL,
+	`owner_rc_id` numeric,
+	`admin_lock_reason` text,
+	`hidden` integer DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_games`("id", "name", "github_author", "github_repo", "owner_rc_id", "admin_lock_reason", "hidden") SELECT "id", "name", "github_author", "github_repo", "owner_rc_id", "admin_lock_reason", "hidden" FROM `games`;--> statement-breakpoint
+DROP TABLE `games`;--> statement-breakpoint
+ALTER TABLE `__new_games` RENAME TO `games`;--> statement-breakpoint
+INSERT INTO `game_versions` SELECT * FROM `__tmp_game_versions`;--> statement-breakpoint
+INSERT INTO `game_authors` SELECT * FROM `__tmp_game_authors`;--> statement-breakpoint
+INSERT INTO `game_dependencies` SELECT * FROM `__tmp_game_dependencies`;--> statement-breakpoint
+INSERT INTO `game_version_categories` SELECT * FROM `__tmp_game_version_categories`;--> statement-breakpoint
+DROP TABLE `__tmp_game_versions`;--> statement-breakpoint
+DROP TABLE `__tmp_game_authors`;--> statement-breakpoint
+DROP TABLE `__tmp_game_dependencies`;--> statement-breakpoint
+DROP TABLE `__tmp_game_version_categories`;--> statement-breakpoint
+CREATE INDEX `games_name_idx` ON `games` (`name`);

--- a/web/drizzle/migrations/meta/0020_snapshot.json
+++ b/web/drizzle/migrations/meta/0020_snapshot.json
@@ -1,0 +1,597 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "84e95fac-542d-4d23-bf5e-e92b6bb96e32",
+  "prevId": "7d3d2892-92ef-4e84-afe2-5b689a151c63",
+  "tables": {
+    "categories": {
+      "name": "categories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "categories_name_unique": {
+          "name": "categories_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_authentications": {
+      "name": "event_authentications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_authentications_github_username_idx": {
+          "name": "event_authentications_github_username_idx",
+          "columns": [
+            "github_username"
+          ],
+          "isUnique": false
+        },
+        "event_authentications_event_id_github_username_unique": {
+          "name": "event_authentications_event_id_github_username_unique",
+          "columns": [
+            "event_id",
+            "github_username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "event_authentications_event_id_events_id_fk": {
+          "name": "event_authentications_event_id_events_id_fk",
+          "tableFrom": "event_authentications",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "totp_secret": {
+          "name": "totp_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_starts_at_ends_at_idx": {
+          "name": "events_starts_at_ends_at_idx",
+          "columns": [
+            "starts_at",
+            "ends_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_authors": {
+      "name": "game_authors",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_version": {
+          "name": "game_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recurse_id": {
+          "name": "recurse_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_authors_game_id_version_idx": {
+          "name": "game_authors_game_id_version_idx",
+          "columns": [
+            "game_id",
+            "game_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_authors_game_id_game_version_game_versions_game_id_version_fk": {
+          "name": "game_authors_game_id_game_version_game_versions_game_id_version_fk",
+          "tableFrom": "game_authors",
+          "tableTo": "game_versions",
+          "columnsFrom": [
+            "game_id",
+            "game_version"
+          ],
+          "columnsTo": [
+            "game_id",
+            "version"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_dependencies": {
+      "name": "game_dependencies",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_version": {
+          "name": "game_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dependency_name": {
+          "name": "dependency_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dependency_version": {
+          "name": "dependency_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_dependencies_game_id_version_idx": {
+          "name": "game_dependencies_game_id_version_idx",
+          "columns": [
+            "game_id",
+            "game_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_dependencies_game_id_game_version_game_versions_game_id_version_fk": {
+          "name": "game_dependencies_game_id_game_version_game_versions_game_id_version_fk",
+          "tableFrom": "game_dependencies",
+          "tableTo": "game_versions",
+          "columnsFrom": [
+            "game_id",
+            "game_version"
+          ],
+          "columnsTo": [
+            "game_id",
+            "version"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_version_categories": {
+      "name": "game_version_categories",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "game_version": {
+          "name": "game_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_version_categories_game_id_version_idx": {
+          "name": "game_version_categories_game_id_version_idx",
+          "columns": [
+            "game_id",
+            "game_version"
+          ],
+          "isUnique": false
+        },
+        "game_version_categories_category_id_idx": {
+          "name": "game_version_categories_category_id_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "game_version_categories_game_id_game_version_category_id_unique": {
+          "name": "game_version_categories_game_id_game_version_category_id_unique",
+          "columns": [
+            "game_id",
+            "game_version",
+            "category_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_version_categories_category_id_categories_id_fk": {
+          "name": "game_version_categories_category_id_categories_id_fk",
+          "tableFrom": "game_version_categories",
+          "tableTo": "categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_version_categories_game_id_game_version_game_versions_game_id_version_fk": {
+          "name": "game_version_categories_game_id_game_version_game_versions_game_id_version_fk",
+          "tableFrom": "game_version_categories",
+          "tableTo": "game_versions",
+          "columnsFrom": [
+            "game_id",
+            "game_version"
+          ],
+          "columnsTo": [
+            "game_id",
+            "version"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_versions": {
+      "name": "game_versions",
+      "columns": {
+        "game_id": {
+          "name": "game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_thumbnail": {
+          "name": "has_thumbnail",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remix_of_game_id": {
+          "name": "remix_of_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remix_of_version": {
+          "name": "remix_of_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "game_versions_game_id_idx": {
+          "name": "game_versions_game_id_idx",
+          "columns": [
+            "game_id"
+          ],
+          "isUnique": false
+        },
+        "game_versions_game_id_version_unique": {
+          "name": "game_versions_game_id_version_unique",
+          "columns": [
+            "game_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "game_versions_game_id_games_id_fk": {
+          "name": "game_versions_game_id_games_id_fk",
+          "tableFrom": "game_versions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_versions_remix_of_game_id_remix_of_version_game_versions_game_id_version_fk": {
+          "name": "game_versions_remix_of_game_id_remix_of_version_game_versions_game_id_version_fk",
+          "tableFrom": "game_versions",
+          "tableTo": "game_versions",
+          "columnsFrom": [
+            "remix_of_game_id",
+            "remix_of_version"
+          ],
+          "columnsTo": [
+            "game_id",
+            "version"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "games": {
+      "name": "games",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_author": {
+          "name": "github_author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_rc_id": {
+          "name": "owner_rc_id",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "admin_lock_reason": {
+          "name": "admin_lock_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "games_name_idx": {
+          "name": "games_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/web/drizzle/migrations/meta/_journal.json
+++ b/web/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1781547452526,
       "tag": "0019_purple_centennial",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1786730327251,
+      "tag": "0020_furry_bushwacker",
+      "breakpoints": true
     }
   ]
 }

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,8 @@
 		"db:migrate:remote": "wrangler d1 migrations apply rcade --remote",
 		"db:studio": "drizzle-kit studio",
 		"db:pull": "node scripts/pull-db.js",
+		"event:create": "node scripts/create-event.js create",
+		"event:list": "node scripts/create-event.js list",
 		"analyze": "vite build --mode production && npx vite-bundle-visualizer"
 	},
 	"devDependencies": {

--- a/web/scripts/create-event.js
+++ b/web/scripts/create-event.js
@@ -1,0 +1,169 @@
+import { execSync } from 'child_process';
+import { randomUUID, randomBytes } from 'crypto';
+
+// Colors and formatting
+const colors = {
+    reset: '\x1b[0m',
+    bright: '\x1b[1m',
+    dim: '\x1b[2m',
+    red: '\x1b[31m',
+    green: '\x1b[32m',
+    yellow: '\x1b[33m',
+    blue: '\x1b[34m',
+    cyan: '\x1b[36m',
+};
+
+function log(emoji, message, color = colors.reset) {
+    console.log(`${emoji}  ${color}${message}${colors.reset}`);
+}
+
+function logSuccess(message) { log('✓', message, colors.green); }
+function logError(message) { log('✗', message, colors.red); }
+function logInfo(message) { log('ℹ', message, colors.blue); }
+function logWarning(message) { log('⚠', message, colors.yellow); }
+
+async function confirm(message) {
+    const readline = await import('readline');
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    return new Promise((resolve) => {
+        rl.question(`${message} (y/N) `, (answer) => {
+            rl.close();
+            resolve(answer.trim().toLowerCase() === 'y');
+        });
+    });
+}
+
+function usage() {
+    console.log(`
+Usage:
+  node scripts/create-event.js create --name "<name>" --starts <ISO date> --ends <ISO date> [--local]
+  node scripts/create-event.js list [--local]
+
+Examples:
+  node scripts/create-event.js create --name "Spring Game Jam" \\
+      --starts "2026-05-01T17:00:00-04:00" --ends "2026-05-01T22:00:00-04:00"
+  node scripts/create-event.js list --local
+`);
+}
+
+function parseArgs(argv) {
+    const args = { _: [] };
+    for (let i = 0; i < argv.length; i++) {
+        if (argv[i].startsWith('--')) {
+            const key = argv[i].slice(2);
+            if (key === 'local') {
+                args.local = true;
+            } else {
+                args[key] = argv[++i];
+            }
+        } else {
+            args._.push(argv[i]);
+        }
+    }
+    return args;
+}
+
+function d1Execute(sql, local) {
+    const target = local ? '--local' : '--remote';
+    const output = execSync(
+        `npx wrangler d1 execute rcade ${target} --command "${sql.replace(/"/g, '\\"')}" --json`,
+        { encoding: 'utf-8' },
+    );
+    // wrangler may prepend non-JSON log lines; the payload starts at the first bracket
+    const jsonStart = output.indexOf('[');
+    return JSON.parse(output.slice(jsonStart));
+}
+
+function formatTime(epochSeconds) {
+    const date = new Date(epochSeconds * 1000);
+    return `${date.toLocaleString()} (${date.toISOString()})`;
+}
+
+async function create(args) {
+    if (!args.name || !args.starts || !args.ends) {
+        logError('create requires --name, --starts, and --ends');
+        usage();
+        process.exit(1);
+    }
+
+    // integer({ mode: 'timestamp' }) columns store epoch SECONDS
+    const startsSec = Math.floor(Date.parse(args.starts) / 1000);
+    const endsSec = Math.floor(Date.parse(args.ends) / 1000);
+    const nowSec = Math.floor(Date.now() / 1000);
+
+    if (Number.isNaN(startsSec) || Number.isNaN(endsSec)) {
+        logError('Could not parse --starts/--ends. Use ISO dates, e.g. 2026-05-01T17:00:00-04:00');
+        process.exit(1);
+    }
+
+    if (endsSec <= startsSec) {
+        logError('--ends must be after --starts');
+        process.exit(1);
+    }
+
+    if (endsSec < nowSec) {
+        logWarning('This event is entirely in the past.');
+    }
+    if (endsSec - startsSec > 14 * 24 * 3600) {
+        logWarning('This event spans more than 14 days — the code will be live the whole time.');
+    }
+
+    const id = randomUUID();
+    const secret = randomBytes(20).toString('hex');
+    const name = args.name.replace(/'/g, "''");
+
+    logInfo(`Event:  ${args.name}`);
+    logInfo(`Starts: ${formatTime(startsSec)}`);
+    logInfo(`Ends:   ${formatTime(endsSec)}`);
+
+    if (!args.local && !(await confirm('Create this event in the PRODUCTION database?'))) {
+        logError('Aborted');
+        process.exit(1);
+    }
+
+    d1Execute(
+        `INSERT INTO "events" ("id","name","starts_at","ends_at","totp_secret","created_at") ` +
+        `VALUES ('${id}','${name}',${startsSec},${endsSec},'${secret}',${nowSec});`,
+        args.local,
+    );
+
+    logSuccess(`Created event ${id}`);
+    logInfo('The cabinet fetches this event (including the code secret) automatically — nothing to install.');
+}
+
+function list(args) {
+    const results = d1Execute(
+        'SELECT id, name, starts_at, ends_at FROM events ORDER BY starts_at DESC LIMIT 20;',
+        args.local,
+    );
+    const rows = results[0]?.results ?? [];
+
+    if (rows.length === 0) {
+        logInfo('No events found.');
+        return;
+    }
+
+    const nowSec = Math.floor(Date.now() / 1000);
+    for (const row of rows) {
+        const active = row.starts_at <= nowSec && nowSec <= row.ends_at;
+        const marker = active ? `${colors.green}● ACTIVE${colors.reset}` : `${colors.dim}○${colors.reset}`;
+        console.log(`${marker} ${colors.bright}${row.name}${colors.reset} ${colors.dim}(${row.id})${colors.reset}`);
+        console.log(`   ${formatTime(row.starts_at)} → ${formatTime(row.ends_at)}`);
+    }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const command = args._[0];
+
+if (command === 'create') {
+    await create(args);
+} else if (command === 'list') {
+    list(args);
+} else {
+    usage();
+    process.exit(command === undefined ? 1 : 0);
+}

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -1,7 +1,7 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 
 import type { Session } from "$lib/auth/user";
-import type { D1Database, R2Bucket } from "@cloudflare/workers-types";
+import type { D1Database, R2Bucket, RateLimit } from "@cloudflare/workers-types";
 
 import { type DefaultSession } from "@auth/sveltekit";
 import type { DefaultJWT } from "@auth/core/jwt";
@@ -39,6 +39,8 @@ declare global {
 				BUCKET_ACCESS_KEY: string,
 				BUCKET_ACCESS_KEY_SECRET: string,
 				GITHUB_DISPATCH_TOKEN: string,
+				CABINET_API_KEY: string,
+				EVENT_AUTH_RATE_LIMITER: RateLimit,
 			};
 			context: {
 				waitUntil(promise: Promise<any>): void;

--- a/web/src/lib/auth/compare.ts
+++ b/web/src/lib/auth/compare.ts
@@ -1,0 +1,19 @@
+// Constant-time string equality that works in both workerd and Node (vite dev).
+// Hashing first fixes the compared length at 32 bytes regardless of input lengths,
+// so neither content nor length leaks through timing.
+export async function timingSafeEqualStrings(a: string, b: string): Promise<boolean> {
+    const encoder = new TextEncoder();
+    const [hashA, hashB] = await Promise.all([
+        globalThis.crypto.subtle.digest("SHA-256", encoder.encode(a)),
+        globalThis.crypto.subtle.digest("SHA-256", encoder.encode(b)),
+    ]);
+
+    const bytesA = new Uint8Array(hashA);
+    const bytesB = new Uint8Array(hashB);
+
+    let diff = 0;
+    for (let i = 0; i < bytesA.length; i++) {
+        diff |= bytesA[i] ^ bytesB[i];
+    }
+    return diff === 0;
+}

--- a/web/src/lib/auth/github.ts
+++ b/web/src/lib/auth/github.ts
@@ -1,7 +1,8 @@
 import * as z from "zod";
 import * as jose from "jose";
 import type { RecurseResponse } from "$lib/rc_oauth";
-import { RecurseAPI } from "$lib/recurse";
+import { RecurseAPI, RecurseAPIError } from "$lib/recurse";
+import { isEventAuthenticated } from "$lib/event";
 import { env } from "$env/dynamic/private"
 
 const GITHUB_OIDC_ISSUER = "https://token.actions.githubusercontent.com";
@@ -47,7 +48,7 @@ export class GithubOIDCValidator {
         }
     }
 
-    public async validate(jwt: string): Promise<GithubOIDCClaims & { recurser: RecurseResponse }> {
+    public async validate(jwt: string): Promise<GithubOIDCClaims & { recurser: RecurseResponse | null }> {
         let payload;
 
         if ("DEBUG_DISABLE_DEPLOYMENT_VALIDATION" in env && env.DEBUG_DISABLE_DEPLOYMENT_VALIDATION == "true") {
@@ -63,7 +64,30 @@ export class GithubOIDCValidator {
         }
 
         const claims = GithubOIDCClaims.parse(payload);
-        const recurser = await this.rcClient.getUserByGithubId(claims.repository_owner);
+
+        let recurser: RecurseResponse | null;
+        try {
+            recurser = await this.rcClient.getUserByGithubId(claims.repository_owner);
+        } catch (error) {
+            // Users registered for a currently-active event may deploy without a
+            // Recurse profile. Only the not-found case falls back; ambiguous or
+            // failed lookups stay fatal.
+            if (!(error instanceof RecurseAPIError) || error.code !== 'USER_NOT_FOUND') {
+                throw error;
+            }
+
+            if (!(await isEventAuthenticated(claims.repository_owner, new Date()))) {
+                throw new RecurseAPIError(
+                    `${error.message} If you're at an rcade event, run ` +
+                    `\`rcade register <your-github-username> <code>\` with the code shown ` +
+                    `on the cabinet, then re-run this deploy.`,
+                    'USER_NOT_FOUND',
+                    403,
+                );
+            }
+
+            recurser = null;
+        }
 
         return {
             ...claims,

--- a/web/src/lib/auth/totp.ts
+++ b/web/src/lib/auth/totp.ts
@@ -1,0 +1,26 @@
+import { generateTotp, TOTP_PARAMS } from "@rcade/api";
+import { timingSafeEqualStrings } from "./compare";
+
+// Accept the current and previous step (a code stays valid for up to ~60s after
+// it appears, so slow typing is fine). Future steps are never accepted — that
+// would only matter if the cabinet clock ran ahead of the server's, which the
+// cabinet logs a skew warning for.
+const ACCEPTED_STEP_OFFSETS = [-1, 0];
+
+export async function verifyTotp(secretHex: string, code: string, nowMs: number): Promise<boolean> {
+    if (!new RegExp(`^\\d{${TOTP_PARAMS.digits}}$`).test(code)) {
+        return false;
+    }
+
+    const stepMs = TOTP_PARAMS.periodSeconds * 1000;
+
+    // Evaluate every slot so timing doesn't reveal which one matched.
+    let ok = false;
+    for (const offset of ACCEPTED_STEP_OFFSETS) {
+        const expected = await generateTotp(secretHex, nowMs + offset * stepMs);
+        if (await timingSafeEqualStrings(expected, code)) {
+            ok = true;
+        }
+    }
+    return ok;
+}

--- a/web/src/lib/db/schema.ts
+++ b/web/src/lib/db/schema.ts
@@ -16,7 +16,7 @@ export const games = sqliteTable('games', {
     name: text('name').notNull(),
     github_author: text("github_author").notNull(),
     github_repo: text("github_repo").notNull(),
-    owner_rc_id: numeric("owner_rc_id").notNull(),
+    owner_rc_id: numeric("owner_rc_id"),
     admin_lock_reason: text("admin_lock_reason"),
     hidden: integer("hidden", { mode: "boolean" }).notNull().default(false),
 }, (t) => [
@@ -86,6 +86,31 @@ export const gameAuthors = sqliteTable('game_authors', {
 ]);
 
 
+/// Events
+
+export const events = sqliteTable('events', {
+    id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+    name: text('name').notNull(),
+    starts_at: integer('starts_at', { mode: 'timestamp' }).notNull(),
+    ends_at: integer('ends_at', { mode: 'timestamp' }).notNull(),
+    // 20 random bytes as lowercase hex; only ever sent to the cabinet.
+    totp_secret: text('totp_secret').notNull(),
+    created_at: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+}, (t) => [
+    index("events_starts_at_ends_at_idx").on(t.starts_at, t.ends_at),
+]);
+
+export const eventAuthentications = sqliteTable('event_authentications', {
+    id: text('id').primaryKey().$defaultFn(() => crypto.randomUUID()),
+    event_id: text('event_id').notNull().references(() => events.id, { onDelete: "cascade" }),
+    // Always stored lowercase; GitHub usernames are case-insensitive.
+    github_username: text('github_username').notNull(),
+    created_at: integer('created_at', { mode: 'timestamp' }).notNull().$defaultFn(() => new Date()),
+}, (t) => [
+    unique().on(t.event_id, t.github_username),
+    index("event_authentications_github_username_idx").on(t.github_username),
+]);
+
 export const categoriesRelations = relations(categories, ({ many }) => ({
     gameVersionCategories: many(gameVersionCategories),
 }));
@@ -116,6 +141,17 @@ export const gameDependenciesRelations = relations(gameDependencies, ({ one }) =
     gameVersion: one(gameVersions, {
         fields: [gameDependencies.gameId, gameDependencies.gameVersion],
         references: [gameVersions.gameId, gameVersions.version],
+    }),
+}));
+
+export const eventsRelations = relations(events, ({ many }) => ({
+    authentications: many(eventAuthentications),
+}));
+
+export const eventAuthenticationsRelations = relations(eventAuthentications, ({ one }) => ({
+    event: one(events, {
+        fields: [eventAuthentications.event_id],
+        references: [events.id],
     }),
 }));
 

--- a/web/src/lib/event.ts
+++ b/web/src/lib/event.ts
@@ -1,0 +1,33 @@
+import { and, gte, lte, eq, desc } from "drizzle-orm";
+import { getDb } from "./db";
+import { events, eventAuthentications } from "./db/schema";
+
+export async function getActiveEvents(now: Date) {
+    return (await getDb())
+        .select()
+        .from(events)
+        .where(and(lte(events.starts_at, now), gte(events.ends_at, now)))
+        .orderBy(desc(events.starts_at));
+}
+
+export async function isEventAuthenticated(githubUsername: string, now: Date): Promise<boolean> {
+    const rows = await (await getDb())
+        .select({ id: eventAuthentications.id })
+        .from(eventAuthentications)
+        .innerJoin(events, eq(eventAuthentications.event_id, events.id))
+        .where(and(
+            eq(eventAuthentications.github_username, githubUsername.toLowerCase()),
+            lte(events.starts_at, now),
+            gte(events.ends_at, now),
+        ))
+        .limit(1);
+
+    return rows.length > 0;
+}
+
+export async function registerEventAuthentication(eventId: string, githubUsername: string): Promise<void> {
+    await (await getDb())
+        .insert(eventAuthentications)
+        .values({ event_id: eventId, github_username: githubUsername.toLowerCase() })
+        .onConflictDoNothing();
+}

--- a/web/src/lib/game.ts
+++ b/web/src/lib/game.ts
@@ -67,14 +67,15 @@ export class Game {
         return new Game(v);
     }
 
-    public static async new(name: string, pushInfo: GithubOIDCClaims & { recurser: RecurseResponse }): Promise<Game> {
+    public static async new(name: string, pushInfo: GithubOIDCClaims & { recurser: RecurseResponse | null }): Promise<Game> {
         const result = await (await getDb()).insert(games).values({
             name,
 
             github_author: pushInfo.repository_owner,
             github_repo: pushInfo.repository,
 
-            owner_rc_id: pushInfo.recurser.id.toString(), // TODO
+            // null for event-authenticated deployers with no Recurse profile
+            owner_rc_id: pushInfo.recurser === null ? null : pushInfo.recurser.id.toString(),
         }).returning();
 
         return new Game({
@@ -295,7 +296,10 @@ export class Game {
                 );
             }
 
-            if (this.data.owner_rc_id !== remixTarget.game.owner_rc_id) {
+            // A null owner (event-authenticated deployer) never passes an
+            // ownership check — without this, null === null would let any two
+            // ownerless games remix each other's private versions.
+            if (this.data.owner_rc_id == null || remixTarget.game.owner_rc_id == null || this.data.owner_rc_id !== remixTarget.game.owner_rc_id) {
                 throw new Error(
                     `Cannot remix an private game owned by somebody else.`
                 );
@@ -356,6 +360,9 @@ export class Game {
             }
 
             if (version.visibility !== "public") {
+                // owner_rc_id may be null (event-authenticated deployer): a
+                // recurser's rc_id never equals null, so private versions of
+                // ownerless games are hidden from everyone.
                 if (auth.for === "public" || (version.visibility === "private" && auth.for === "recurser" && auth.rc_id !== this.data.owner_rc_id))
                     return undefined;
             }

--- a/web/src/routes/api/v1/events/auth/+server.ts
+++ b/web/src/routes/api/v1/events/auth/+server.ts
@@ -1,0 +1,104 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import * as z from "zod";
+import { ZodError } from "zod";
+import { getActiveEvents, registerEventAuthentication } from "$lib/event";
+import { verifyTotp } from "$lib/auth/totp";
+import { TOTP_PARAMS } from "@rcade/api";
+
+const noCacheHeaders = {
+    'Cache-Control': 'private, no-store',
+    'CDN-Cache-Control': 'no-store',
+};
+
+function jsonResponse(body: object, status: number): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json', ...noCacheHeaders }
+    });
+}
+
+const EventAuthRequest = z.object({
+    // GitHub username rules: 1-39 chars, alphanumeric with inner hyphens
+    github_username: z.string().regex(/^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/,
+        "Invalid GitHub username"),
+    code: z.string().regex(new RegExp(`^\\d{${TOTP_PARAMS.digits}}$`),
+        `Code must be ${TOTP_PARAMS.digits} digits`),
+});
+
+export const POST: RequestHandler = async ({ request, platform, getClientAddress }) => {
+    const limiter = platform?.env?.EVENT_AUTH_RATE_LIMITER;
+    if (limiter) {
+        let key = "unknown";
+        try {
+            key = getClientAddress();
+        } catch {
+            // dev server without client address info
+        }
+
+        try {
+            const { success } = await limiter.limit({ key });
+            if (!success) {
+                return jsonResponse({ error: 'Too many attempts. Please wait a minute and try again.' }, 429);
+            }
+        } catch (error) {
+            // Fail open: a rate-limiter hiccup shouldn't brick onboarding mid-event.
+            console.error('Rate limiter error, failing open:', error);
+        }
+    }
+
+    let body;
+    try {
+        body = await request.json();
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            return jsonResponse({ error: 'Invalid JSON in request body' }, 400);
+        }
+        throw error;
+    }
+
+    let auth;
+    try {
+        auth = EventAuthRequest.parse(body);
+    } catch (error) {
+        if (error instanceof ZodError) {
+            const issues = error.issues.map(i => `${i.path.join('.')}: ${i.message}`);
+            return jsonResponse({ error: 'Invalid request', details: issues }, 400);
+        }
+        throw error;
+    }
+
+    try {
+        const now = new Date();
+        const active = await getActiveEvents(now);
+
+        if (active.length === 0) {
+            return jsonResponse({ error: 'No event is currently active.' }, 404);
+        }
+
+        const matched = [];
+        for (const event of active) {
+            if (await verifyTotp(event.totp_secret, auth.code, now.getTime())) {
+                matched.push(event);
+            }
+        }
+
+        if (matched.length === 0) {
+            return jsonResponse({
+                error: `Invalid or expired code. Codes rotate every ${TOTP_PARAMS.periodSeconds} seconds — check the cabinet screen and try again.`
+            }, 401);
+        }
+
+        for (const event of matched) {
+            await registerEventAuthentication(event.id, auth.github_username);
+        }
+
+        return jsonResponse({
+            success: true,
+            github_username: auth.github_username.toLowerCase(),
+            events: matched.map(event => ({ id: event.id, name: event.name })),
+        }, 200);
+    } catch (error) {
+        console.error('Event auth failed:', error);
+        return jsonResponse({ error: 'Event authentication failed. Please try again.' }, 500);
+    }
+};

--- a/web/src/routes/api/v1/events/current/+server.ts
+++ b/web/src/routes/api/v1/events/current/+server.ts
@@ -1,0 +1,64 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { env } from "$env/dynamic/private";
+import { getActiveEvents } from "$lib/event";
+import { timingSafeEqualStrings } from "$lib/auth/compare";
+
+const noCacheHeaders = {
+    'Cache-Control': 'private, no-store',
+    'CDN-Cache-Control': 'no-store',
+};
+
+function jsonResponse(body: object, status: number): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json', ...noCacheHeaders }
+    });
+}
+
+export const GET: RequestHandler = async ({ request }) => {
+    // This endpoint returns a TOTP secret, so unlike the games routes it must
+    // hard-fail when the key is unconfigured (`Bearer undefined` spoof) and
+    // compare in constant time.
+    const configuredKey = env.CABINET_API_KEY;
+    if (!configuredKey) {
+        console.error('CABINET_API_KEY is not configured; refusing /events/current');
+        return jsonResponse({ error: 'Server misconfigured' }, 500);
+    }
+
+    const header = request.headers.get("Authorization");
+    if (!header?.startsWith("Bearer ")) {
+        return jsonResponse({ error: 'Missing or invalid Authorization header. Expected: Bearer <token>' }, 401);
+    }
+
+    if (!(await timingSafeEqualStrings(header.slice(7), configuredKey))) {
+        return jsonResponse({ error: 'Unauthorized' }, 401);
+    }
+
+    try {
+        const now = new Date();
+        const active = await getActiveEvents(now);
+        // Most recently started event wins if several overlap; /events/auth
+        // still accepts codes from any active event.
+        const event = active[0];
+
+        if (event === undefined) {
+            return jsonResponse({ active: false, server_time: Date.now() }, 200);
+        }
+
+        return jsonResponse({
+            active: true,
+            event: {
+                id: event.id,
+                name: event.name,
+                starts_at: event.starts_at.toISOString(),
+                ends_at: event.ends_at.toISOString(),
+                totp_secret: event.totp_secret,
+            },
+            // epoch ms; the cabinet compares against its own clock to warn on skew
+            server_time: Date.now(),
+        }, 200);
+    } catch (error) {
+        console.error('Database error:', error);
+        return jsonResponse({ error: 'Failed to fetch current event' }, 500);
+    }
+};

--- a/web/wrangler.toml
+++ b/web/wrangler.toml
@@ -28,6 +28,14 @@ migrations_dir = "drizzle/migrations"
 binding = "STORE"
 bucket_name = "rcade"
 
+# Rate limiting binding (open beta, hence "unsafe"). Limits POST /api/v1/events/auth
+# to 10 requests per 60s per client IP. namespace_id is an arbitrary account-unique id.
+[[unsafe.bindings]]
+name = "EVENT_AUTH_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 10, period = 60 }
+
 [observability.logs]
 enabled = true
 head_sampling_rate = 1


### PR DESCRIPTION
During events (game jams, open houses), people who aren't in the Recurse directory can now deploy games to the cabinet.

## How it works
- An `events` row (server-minted TOTP secret, start/end window) defines an active event; `web/scripts/create-event.js` creates them.
- **The cabinet is the clock**: the Electron main process fetches the secret from `GET /api/v1/events/current` (CABINET_API_KEY-gated, constant-time compare) and mints a rotating 6-digit code locally, so a network blip doesn't blank the screen. The menu iframe only ever sees the derived code, pushed over the existing plugin channel, rendered in one line below the scroller dots.
- `rcade register <github-username> <code>` (interactive when args omitted) hits `POST /api/v1/events/auth` — rate-limited 10/min/IP via a new Workers ratelimit binding, accepting the current and previous 30s window.
- Deploy validation falls back: when the Recurse lookup returns USER_NOT_FOUND, an `event_authentications` row in a currently-active event authorizes the deploy (games get `owner_rc_id: NULL`). Registering a username is a capability grant, not an identity claim — pushes still require GitHub OIDC from a repo owned by that username.

## Migration note (0020)
drizzle's generated recreate of `games` **cascade-deletes all game_versions on D1** (D1 ignores `PRAGMA foreign_keys=OFF`, and `defer_foreign_keys` doesn't stop cascade actions). The committed migration is hand-edited to snapshot and restore the four affected child tables. Verified against an import of today's production export: identical row counts and content checksums across all tables, no orphans, no leftovers. Production backup + D1 Time Travel bookmark captured pre-deploy.

## Verified
- RFC 6238 test vectors (first tests in the repo, `pnpm --filter @rcade/api test`)
- Full local e2e: key gating, code verify (current/previous/future windows), idempotent registration, rate limiting, no-active-event paths, CLI success/error
- Live deploy fallback with a real RC PAT: unregistered non-Recurser → 403 with register hint; registered → game created with NULL owner
- Emulator run: cabinet minted codes locally, menu line rendered and rotated on 30s boundaries

## Rollout
Cabinet needs a rebuild/release (`release-cabinet` dispatch) **before the first event goes live** — an old cabinet's zod schema rejects games with `owner_rc_id: null`. Until an event exists there's no ordering pressure. `publish-cli` dispatch needed so users get `rcade register`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)