### PR TITLE
justfile: deploy-nuc as admin, the NUC's maintenance user

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,7 +12,7 @@ deploy-marquee ip="100.123.178.9":
 [doc('Deploy nuc (production cabinet)')]
 [group('deploy')]
 deploy-nuc ip="100.111.184.1":
-    nix --extra-experimental-features 'nix-command flakes' run nixpkgs#nixos-rebuild -- switch --flake .#rcade-nuc --target-host rcade@{{ ip }} --build-host rcade@{{ ip }} --sudo
+    nix --extra-experimental-features 'nix-command flakes' run nixpkgs#nixos-rebuild -- switch --flake .#rcade-nuc --target-host admin@{{ ip }} --build-host admin@{{ ip }} --sudo
 
 [doc('Build marquee SD card image (decrypts WiFi PSK from agenix)')]
 [group('build')]


### PR DESCRIPTION
The maintainer keys and passwordless sudo live on `users.users.admin` (machines/rcade-nuc/configuration.nix); `rcade` is the kiosk auto-login account with no authorized keys, so `just deploy-nuc` fails with publickey denied as written. The marquee recipe also uses `rcade@` — left untouched since I haven't verified that machine's user setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)