### PR TITLE
Add support to build for linux-arm64

### DIFF
--- a/.github/workflows/release-cabinet.yaml
+++ b/.github/workflows/release-cabinet.yaml
@@ -158,6 +158,9 @@ jobs:
     name: Build Linux
     needs: bump
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x64, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -177,13 +180,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build Cabinet
-        run: pnpm run build:cabinet-linux
+        run: pnpm run build:cabinet-linux-${{ matrix.arch }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: cabinet-linux
-          path: cabinet/release/rcade-cabinet-linux-*.AppImage
+          name: cabinet-linux-${{ matrix.arch }}
+          path: cabinet/release/rcade-cabinet-linux-${{ matrix.arch }}.AppImage
 
   release:
     name: Create Release
@@ -211,4 +214,5 @@ jobs:
             artifacts/cabinet-macos-x64/*
             artifacts/cabinet-macos-arm64/*
             artifacts/cabinet-windows/*
-            artifacts/cabinet-linux/*
+            artifacts/cabinet-linux-x64/*
+            artifacts/cabinet-linux-arm64/*

--- a/cabinet/package.json
+++ b/cabinet/package.json
@@ -15,7 +15,8 @@
     "build:cabinet-mac-x64": "pnpm run build:main && pnpm run build:preload && vite build && electron-builder --mac --x64",
     "build:cabinet-mac-arm64": "pnpm run build:main && pnpm run build:preload && vite build && electron-builder --mac --arm64",
     "build:cabinet-win": "pnpm run build:main && pnpm run build:preload && vite build && electron-builder --win",
-    "build:cabinet-linux": "pnpm run build:main && pnpm run build:preload && vite build && electron-builder --linux"
+    "build:cabinet-linux-x64": "pnpm run build:main && pnpm run build:preload && vite build && electron-builder --linux",
+    "build:cabinet-linux-arm64": "pnpm run build:main && pnpm run build:preload && vite build && electron-builder --linux --arm64"
   },
   "dependencies": {
     "@fireworks-js/svelte": "^2.10.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build:cabinet-mac-x64": "turbo build:cabinet-mac-x64 --filter=@rcade/client",
     "build:cabinet-mac-arm64": "turbo build:cabinet-mac-arm64 --filter=@rcade/client",
     "build:cabinet-win": "turbo build:cabinet-win --filter=@rcade/client",
-    "build:cabinet-linux": "turbo build:cabinet-linux --filter=@rcade/client",
+    "build:cabinet-linux-x64": "turbo build:cabinet-linux --filter=@rcade/client",
+    "build:cabinet-linux-arm64": "turbo build:cabinet-linux --filter=@rcade/client",
     "check": "turbo check",
     "prepare": "husky"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -26,7 +26,12 @@
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", "release/**"]
     },
-    "build:cabinet-linux": {
+    "build:cabinet-linux-x64": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": ["dist/**", "release/**"]
+    },
+    "build:cabinet-linux-arm64": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**", "release/**"]


### PR DESCRIPTION
Adds an option to build the cabinet for linux-arm64 and updates the github action to call this build on releases.

Let me know if there's anything I need to add here that I am missing.